### PR TITLE
Update eggnog data url

### DIFF
--- a/admin/Build_Trinotate_Boilerplate_SQLite_db.pl
+++ b/admin/Build_Trinotate_Boilerplate_SQLite_db.pl
@@ -18,7 +18,7 @@ my $UTILDIR = "$FindBin::RealBin/util";
 
 ## Resources:
 my $SPROT_DAT_URL = "ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.dat.gz";
-my $EGGNOG_DAT_URL = "http://eggnogdb.embl.de/download/latest/data/NOG/NOG.annotations.tsv.gz";
+my $EGGNOG_DAT_URL = "http://eggnogdb.embl.de/download/eggnog_4.5/data/NOG/NOG.annotations.tsv.gz";
 my $GENE_ONTOLOGY_DAT_URL = "http://purl.obolibrary.org/obo/go/go-basic.obo";
 my $PFAM_DAT_URL = "ftp://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz";
 #my $PFAM2GO_DAT_URL = "http://www.geneontology.org/external2go/pfam2go"; # ftp://ftp.geneontology.org/pub/go/external2go/pfam2go


### PR DESCRIPTION
Try to fix https://github.com/Trinotate/Trinotate/issues/57
I cannot find the file in http://eggnogdb.embl.de/download/latest/, so I have added the file found in http://eggnogdb.embl.de/download/eggnog_4.5/