### PR TITLE
Use standard shebang line in admin scripts

### DIFF
--- a/admin/util/EMBL_swissprot_parser.pl
+++ b/admin/util/EMBL_swissprot_parser.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/admin/util/PFAM_dat_parser.pl
+++ b/admin/util/PFAM_dat_parser.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
There are some scripts which use different perl paths, which can cause conflicts leading to "undefined symbol: Perl_xs_handshake" errors on some systems. Using env to decide the perl version across all scripts helps ensure the same perl is used everywhere.
